### PR TITLE
Add screen/tmux tools by default

### DIFF
--- a/stage3/00-install-packages/00-packages
+++ b/stage3/00-install-packages/00-packages
@@ -13,3 +13,5 @@ obconf
 arandr
 libcamera-tools
 libcamera-apps
+screen
+tmux


### PR DESCRIPTION
Hi,

What about including screen / tmux tools by default into the built image?

Given that we can often have multiple terminals required in parallel (mitmproxy, adb shell, etc.), it might be useful for quite a lot of users?

Best,